### PR TITLE
Fixed two issues with handling of encoding

### DIFF
--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -112,7 +112,7 @@ class Logbook(object):
         self._user = user
         self._password = self._handle_pswd(password, encrypt_pwd)
 
-    def post(self, message, msg_id=None, reply=False, attributes=None, attachments=None, encoding='plain',
+    def post(self, message, msg_id=None, reply=False, attributes=None, attachments=None, encoding=None,
              **kwargs):
         """
         Posts message to the logbook. If msg_id is not specified new message will be created, otherwise existing
@@ -144,10 +144,11 @@ class Logbook(object):
 
         attachments = attachments or []
 
-        if encoding not in ['plain', 'HTML', 'ELCode']:
-            raise LogbookMessageRejected('Invalid message encoding. Valid options: plain, HTML, ELCode.')
+        if encoding is not None:
+            if encoding not in ['plain', 'HTML', 'ELCode']:
+                raise LogbookMessageRejected('Invalid message encoding. Valid options: plain, HTML, ELCode.')
+            attributes['Encoding'] = encoding
 
-        attributes['encoding'] = encoding
         attributes_to_edit = dict()
         if msg_id:
             # Message exists, we can continue
@@ -444,7 +445,6 @@ class Logbook(object):
             attributes.pop('Date', None)
             attributes.pop('Attachment', None)
             attributes.pop('Text', None)  # Remove this one because it will be send attachment like
-            attributes.pop('Encoding', None)
             
     def _replace_special_characters_in_attribute_keys(self, attributes):
         """


### PR DESCRIPTION
The handling of the encoding did have some issues:
1. the exisiting encoding in case of editing an entry was reverted to plain as a default
2. the encoding attribute was removed from the data before it was sent making it impossible to keep or set any encoding other than the default encoding

With this fix encoding can be None as a parameter for the post() method and only if not none it will be set as an attribute as well as the existing encoding is preserved in the attribute list (in case of encoding=None)