### PR TITLE
fixes regex for special char handling 

### DIFF
--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -454,7 +454,7 @@ class Logbook(object):
         :param attributes: dictionary of attributes to be cleaned.
         :return: attributes with replaced keys
         """
-        cleanedAttributes = {re.sub('[^0-9a-zA-Z]+', '_', key): value for key, value in attributes.items()}
+        cleanedAttributes = {re.sub('[^0-9a-zA-Z]', '_', key): value for key, value in attributes.items()}
         return cleanedAttributes
 
     def _make_user_and_pswd_cookie(self):


### PR DESCRIPTION
There was a bug in the regex expression which would fail if multiple adjacent special chars are present, which all would have been replaced by just one underscore instead of replacing every special char with its own underscore