### PR TITLE
changed sha256_crypt.hash() to sha256_crypt.encrypt()

### DIFF
--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -566,7 +566,7 @@ def _handle_pswd(password, encrypt=True):
     """
     if encrypt and password:
         from passlib.hash import sha256_crypt
-        return sha256_crypt.encrypt(password, salt='', rounds=5000)[4:]
+        return sha256_crypt.hash(password, salt='', rounds=5000)[4:]
     elif password and password.startswith('$5$$'):
         return password[4:]
     else:


### PR DESCRIPTION
fixes:
`DeprecationWarning: the method passlib.handlers.sha2_crypt.sha256_crypt.encrypt() is deprecated as of Passlib 1.7, and will be removed in Passlib 2.0, use .hash() instead.`