### PR TITLE
changed sha256_crypt.hash(password, **settings) to sha256_crypt.using(**settings).hash(password)

### DIFF
--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -566,7 +566,7 @@ def _handle_pswd(password, encrypt=True):
     """
     if encrypt and password:
         from passlib.hash import sha256_crypt
-        return sha256_crypt.hash(password, salt='', rounds=5000)[4:]
+        return sha256_crypt.using(salt='', rounds=5000).hash(password)[4:]
     elif password and password.startswith('$5$$'):
         return password[4:]
     else:


### PR DESCRIPTION
fixes: DeprecationWarning: passing settings to sha256_crypt.hash() is deprecated, and won't be supported in Passlib 2.0; use 'sha256_crypt.using(**settings).hash(secret)' instead