### PR TITLE
Fix empty search bug

### DIFF
--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -333,6 +333,13 @@ class Logbook(object):
             params.update(search_term)
         else:
             params.update({scope: search_term})
+            
+        # Remove empty entries from params, since ELog will redirect such requests
+        # and remove them anyway, but the redirect leads to unexpected results
+        keys = list(params.keys())
+        for key in keys:
+            if params[key] == "":
+                params.pop(key)
 
         try:
             response = requests.get(self._url, params=params, headers=request_headers,

--- a/tests/test_logbook.py
+++ b/tests/test_logbook.py
@@ -41,6 +41,16 @@ class TestClass(unittest.TestCase):
         logbook = elog.open('https://elog-gfa.psi.ch/SwissFEL+test/')
         ids = logbook.search("Powersupply")
         print(ids)
+        
+    def test_search_empty(self):
+        logbook = elog.open('https://elog-gfa.psi.ch/SwissFEL+test/')
+        ids = logbook.search("")
+        print(ids)
+        
+    def test_search_dict(self):
+        logbook = elog.open('https://elog-gfa.psi.ch/SwissFEL+test/')
+        ids = logbook.search({"subtext": "Powersupply"})
+        print(ids)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Searching for empty content did trigger an unexpected error, since ELog will remove all empty URL parameters and redirect to the "clean" URL, which results in a response for the search without the search result and wrong interpretation by `_validate_response`

Also add test for empty search and test for a simple dict search. (Could not test the tests, since public access to the Elog is most likely forbidden, but I added similar tests to my local test suite)