### PR TITLE
Posting messages and attributes with special characters as èéàäö

### DIFF
--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -194,7 +194,7 @@ class Logbook(object):
 
         # Make requests module think that Text is a "file". This is the only way to force requests to send data as
         # multipart/form-data even if there are no attachments. Elog understands only multipart/form-data
-        files_to_attach.append(('Text', ('', message)))
+        files_to_attach.append(('Text', ('', message, 'text/html;charset=utf-8')))
 
         # Base attributes are common to all messages
         self._add_base_msg_attributes(attributes_to_edit)

--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -194,7 +194,7 @@ class Logbook(object):
 
         # Make requests module think that Text is a "file". This is the only way to force requests to send data as
         # multipart/form-data even if there are no attachments. Elog understands only multipart/form-data
-        files_to_attach.append(('Text', ('', message.encode('l1'))))
+        files_to_attach.append(('Text', ('', message.encode('iso-8859-1'))))
 
         # Base attributes are common to all messages
         self._add_base_msg_attributes(attributes_to_edit)
@@ -262,7 +262,7 @@ class Logbook(object):
         attributes = dict()
         attachments = list()
 
-        returned_msg = resp_message.decode('utf-8', 'ignore').splitlines()
+        returned_msg = resp_message.decode('iso-8859-1', 'ignore').splitlines()
         delimiter_idx = returned_msg.index('========================================')
 
         message = '\n'.join(returned_msg[delimiter_idx + 1:])
@@ -528,7 +528,7 @@ def _encode_values(attributes):
     encoded_attributes = {}
     for key, value in attributes.items():
         if isinstance(value, str):
-            encoded_attributes[key] = value.encode('l1')
+            encoded_attributes[key] = value.encode('iso-8859-1')
         else:
             encoded_attributes[key] = value
     return encoded_attributes

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.md')).read()
 
 setup(name='py_elog',
-      version='1.3.13',
+      version='1.3.14',
       description="Python library to access Elog.",
       long_description=README,
       long_description_content_type="text/markdown",

--- a/tests/test_logbook.py
+++ b/tests/test_logbook.py
@@ -4,40 +4,25 @@ import elog
 
 
 
-
 class TestClass(unittest.TestCase):
 
     # TODO add test for delete
     # TODO add description how to run the test docker container for testing
 
     elog_hostname = 'https://elog.psi.ch/elogs/Linux+Demo/'
-
+    message = 'This message text is new'
 
     def test_get_message_ids(self):
         logbook = elog.open(self.elog_hostname)
         message_ids = logbook.get_message_ids()
-        print(len(message_ids))
-        print(message_ids)
-
+        
     def test_get_last_message_id(self):
 
         logbook = elog.open(self.elog_hostname)
-        msg_id = logbook.post('This is message text is new', attributes={'Author':'AB', 'Type':'Routine'})
+        msg_id = logbook.post(self.message, attributes={'Author':'AB', 'Type':'Routine'})
         message_id = logbook.get_last_message_id()
-
-        print(msg_id)
-        print(message_id)
         self.assertEqual(msg_id, message_id, "Created message does not show up as last edited message")
         
-
-    def test_read(self):
-
-        logbook = elog.open(self.elog_hostname)
-        message, attributes, attachments = logbook.read(logbook.get_last_message_id())
-        print(message)
-        self.assertEqual(message, 'This is message text is new', "Unable to retrieve message")
-
-
     def test_edit(self):
         logbook = elog.open(self.elog_hostname)
         logbook.post('hehehehehe', msg_id=logbook.get_last_message_id(), attributes={"Subject": 'py_elog test [mod]'})
@@ -45,17 +30,36 @@ class TestClass(unittest.TestCase):
     def test_search(self):
         logbook = elog.open(self.elog_hostname)
         ids = logbook.search("message")
-        print(ids)
         
     def test_search_empty(self):
         logbook = elog.open(self.elog_hostname)
         ids = logbook.search("")
-        print(ids)
         
     def test_search_dict(self):
         logbook = elog.open(self.elog_hostname)
         ids = logbook.search({"Category": "Hardware"})
-        print(ids)
+        
+    def test_post_special_characters(self):
+        logbook = elog.open(self.elog_hostname)
+        attributes = { 'Author' : 'Me', 'Type' : 'Other', 'Category' : 'General', 
+                      'Subject' : 'This is a test of UTF-8 characters like èéöä'}
+        message = 'Just to be clear this is a general test using UTF-8 characters like èéöä.'  
+        msg_id = logbook.post(message,  reply=False, attributes=attributes,encoding='HTML')
+        read_msg, read_attr, read_att = logbook.read(msg_id)
+        
+        mess_ok = message == read_msg
 
+        attr_ok = True
+        for key in attributes:
+            if attributes[key] == read_attr[key]:
+                attr_ok = attr_ok and True
+            else:
+                attr_ok = attr_ok and False
+
+        whole_test = attr_ok and mess_ok
+        
+        self.assertTrue(whole_test)
+        
 if __name__ == '__main__':
     unittest.main()
+    


### PR DESCRIPTION
This pull request is adding the possibility to post and read a message with special characters.
Special characters are also accepted in the attributes. 
 
The idea is that the elog server is expecting to receive a message with latin-1 encoding, but python is sending an UTF-8 encoded strings.

It includes pull request #34 that implement only the read back capability.