### PR TITLE
Allow request post and get to timeout

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,8 +34,9 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.5.0
+
       with:
         user: __token__
         password: ${{ secrets.PYPI_SECRET }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,6 @@ jobs:
     - name: Publish package
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.5.0
-
       with:
         user: __token__
         password: ${{ secrets.PYPI_SECRET }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![conda_publish](https://github.com/paulscherrerinstitute/py_elog/workflows/conda_publish/badge.svg)
 [![Python application](https://github.com/abulgher/py_elog/actions/workflows/python-app.yml/badge.svg?branch=master)](https://github.com/abulgher/py_elog/actions/workflows/python-app.yml)
+[![Upload Python Package](https://github.com/abulgher/py_elog/actions/workflows/python-publish.yml/badge.svg)](https://github.com/abulgher/py_elog/actions/workflows/python-publish.yml)
 
 # Overview
 This Python module provides a native interface [electronic logbooks](https://midas.psi.ch/elog/). It is compatible with Python versions 3.5 and higher.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ message, attributes, attachments = logbook.read(23)
 
 ```python
 # Create new message with some text, attributes (dict of attributes + kwargs) and attachments
-new_msg_id = logbook.post('This is message text', attributes=dict_of_attributes, attachments=list_of_attachments, attribute_as_param='value')
+new_msg_id = logbook.post('This is message text', attributes=dict_of_attributes, attachments=list_of_attachments,
+                          attribute_as_param='value')
 ```
  
 What attributes are required is determined by the configuration of the elog server (keywork `Required Attributes`).
@@ -76,14 +77,16 @@ new_msg_id = logbook.post('This is message text', author='me', type='Routine')
 
 ```python
 # Reply to message with ID=23
-new_msg_id = logbook.post('This is a reply', msg_id=23, reply=True, attributes=dict_of_attributes, attachments=list_of_attachments, attribute_as_param='value')
+new_msg_id = logbook.post('This is a reply', msg_id=23, reply=True, attributes=dict_of_attributes,
+                          attachments=list_of_attachments, attribute_as_param='value')
 ```
 
 ## Edit Message
 
 ```python
 # Edit message with ID=23. Changed message text, some attributes (dict of edited attributes + kwargs) and new attachments
-edited_msg_id = logbook.post('This is new message text', msg_id=23, attributes=dict_of_changed_attributes, attachments=list_of_new_attachments, attribute_as_param='new value')
+edited_msg_id = logbook.post('This is new message text', msg_id=23, attributes=dict_of_changed_attributes,
+                             attachments=list_of_new_attachments, attribute_as_param='new value')
 ```
 
 ## Search Messages
@@ -92,7 +95,7 @@ edited_msg_id = logbook.post('This is new message text', msg_id=23, attributes=d
 # Search for text in messages or specify attributes for search, returns list of message ids
 logbook.search('Hello World')
 logbook.search('Hello World', n_results=20, scope='attribname')
-logbook.search({'attribname' : 'Hello World', ... })
+logbook.search({'attribname': 'Hello World', ...})
 ```
 
 ## Delete Message (and all its replies)

--- a/elog/logbook_exceptions.py
+++ b/elog/logbook_exceptions.py
@@ -7,6 +7,8 @@ class LogbookAuthenticationError(LogbookError):
     """ Raise when problem with username and password."""
     pass
 
+class LogbookServerTimeout(LogbookError):
+    """ Raise when the request to the logbook server timeouts. """
 
 class LogbookServerProblem(LogbookError):
     """ Raise when problem accessing logbook server."""

--- a/tests/test_logbook.py
+++ b/tests/test_logbook.py
@@ -1,6 +1,7 @@
 import unittest
 # import logging
 import elog
+from elog.logbook_exceptions import *
 
 
 
@@ -19,10 +20,16 @@ class TestClass(unittest.TestCase):
     def test_get_last_message_id(self):
 
         logbook = elog.open(self.elog_hostname)
-        msg_id = logbook.post(self.message, attributes={'Author':'AB', 'Type':'Routine'})
+        msg_id = logbook.post(self.message, attributes={'Author': 'AB', 'Type': 'Routine'})
         message_id = logbook.get_last_message_id()
         self.assertEqual(msg_id, message_id, "Created message does not show up as last edited message")
-        
+
+    def test_get_last_message_id_with_short_timeout(self):
+
+        logbook = elog.open(self.elog_hostname)
+        self.assertRaises(LogbookServerTimeout,  logbook.post,
+                          self.message, attributes={'Author': 'AB', 'Type': 'Routine'}, timeout=0.01)
+
     def test_edit(self):
         logbook = elog.open(self.elog_hostname)
         logbook.post('hehehehehe', msg_id=logbook.get_last_message_id(), attributes={"Subject": 'py_elog test [mod]'})
@@ -44,7 +51,7 @@ class TestClass(unittest.TestCase):
         attributes = { 'Author' : 'Me', 'Type' : 'Other', 'Category' : 'General', 
                       'Subject' : 'This is a test of UTF-8 characters like èéöä'}
         message = 'Just to be clear this is a general test using UTF-8 characters like èéöä.'  
-        msg_id = logbook.post(message,  reply=False, attributes=attributes,encoding='HTML')
+        msg_id = logbook.post(message, reply=False, attributes=attributes, encoding='HTML')
         read_msg, read_attr, read_att = logbook.read(msg_id)
         
         mess_ok = message == read_msg


### PR DESCRIPTION
According to the [requests documentation](https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts) all production codes should implement a Timeout for all requests to avoid application hanging and freezing due to a unresponsive server. 

I have added a timeout parameter to all methods invoking a post or get requests. The timeout is by default None, it means that the API structure is not modified, as proved in the test suite.  In the test suite, I have added a test with a very short timeout to prove the functionality of the newly introduced feature.

When a timeout is occurring, a new elog exception is raised so that the API user can handle it. 


