### PR TITLE
Adding support for Bearer Token (OAuth2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ logbook.delete(23)
 
 __Note:__ Due to the way elog implements delete this function is only supported on english logbooks.
 
+### JWT-based authentication
+If the access to the elog is protected by an OAuth2 layer, it is possible to add the token (or a callable returning
+the token) when opening the connection to the ELOG server
+
+```python
+logbook = elog.open(
+    'https://elog.example.com', 'my_logbook', user='my_username', bearer_token=open("/path/to/my/token").read()
+)
+```
+
+This includes the Access token in the request headers of the following queries to the ELOG.
+
+
 # Installation
 The Elog module and only depends on the `passlib` and `requests` library used for password encryption and http(s) communication. It is packed as [anaconda package](https://anaconda.org/paulscherrerinstitute/elog) and can be installed as follows:
 

--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -885,6 +885,15 @@ def _validate_response(response):
                     # it was not possible to get the msg_id. 
                     # this may happen when deleting the last entry of a logbook
                     msg_id = None
+                
+                if msg_id is None:
+                    try:
+                        msg_id = int(re.findall("Location: [^\r]*/([0-9]+)\r", response.text)[0])
+                    except ValueError:
+                        msg_id = None
+                    except IndexError:
+                        msg_id = None
+
 
         if b'type=password' in response.content or b'type="password"' in response.content:
             # Not too smart to check this way, but no other indication of this kind of error.

--- a/elog/logbook.py
+++ b/elog/logbook.py
@@ -109,6 +109,7 @@ class Logbook(object):
         self._password = _handle_pswd(password, encrypt_pwd)
         self._bearer_token_arg = bearer_token
 
+    @property
     def _bearer_token(self):
         return self._bearer_token_arg() if callable(self._bearer_token_arg) else self._bearer_token_arg
 
@@ -855,6 +856,7 @@ def _validate_response(response):
                 raise LogbookMessageRejected('Rejected because of unknown error.')
 
         # Other unknown errors
+        print (response.status_code, response.reason, response.text)
         raise LogbookMessageRejected('Rejected because of unknown error.')
     else:
         location = response.headers.get('Location')


### PR DESCRIPTION
Using oauth2proxy it is not difficult to configure ELOG to authenticate users based on IAM client.
Unfortunately, passing through the proxy with this python client requires adding a header including the Bearer token generated by the user interacting with the IAM.

This pull request introduces an additional argument to the constructor of the elog object to pass an access token.
Since the client application may have it's own workflow to keep the access token updated, the argument can be a callable, in which case it is called to retrieve the token at each call.

Example.
```python
logbook = elog.open(
    'https://elog.example.com', 
    'my_logbook', 
    use_ssl=True, 
    port=443, 
    user='my_username',
    bearer_token=lambda: open("/path/to/my/token").read()
)

logbook.get_message_ids()
```